### PR TITLE
Fix binary message publishing

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,8 +1,18 @@
 Version History
 ===============
 
-`0.0.1`_ Sept 08, 2015
----------------------
+`0.1.2`_ Sept 25, 2015
+----------------------
+- Don't log the message body
+
+`0.1.1`_ Sept 24, 2015
+----------------------
+- Clean up installation and testing environment
+
+`0.1.0`_ Sept 23, 2015
+----------------------
  - Initial implementation
 
-.. _0.0.1: https://github.com/sprockets/sprockets.amqp/compare/0.0.0...0.0.1
+.. _0.1.2: https://github.com/sprockets/sprockets.amqp/compare/0.1.1...0.1.2
+.. _0.1.1: https://github.com/sprockets/sprockets.amqp/compare/0.1.0...0.1.1
+.. _0.1.0: https://github.com/sprockets/sprockets.amqp/compare/551982c...0.1.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='sprockets.mixins.amqp',
-    version='0.1.1',
+    version='0.1.2',
     description='Mixin for publishing events to RabbitMQ',
     long_description=open('README.rst').read(),
     url='https://github.com/sprockets/sprockets.mixins.amqp',

--- a/sprockets/mixins/amqp.py
+++ b/sprockets/mixins/amqp.py
@@ -22,7 +22,7 @@ from tornado import ioloop
 from tornado import locks
 from tornado import web
 
-version_info = (0, 1, 1)
+version_info = (0, 1, 2)
 __version__ = '.'.join(str(v) for v in version_info)
 
 LOGGER = logging.getLogger(__name__)

--- a/sprockets/mixins/amqp.py
+++ b/sprockets/mixins/amqp.py
@@ -126,8 +126,8 @@ class AMQP(object):
         """
         if not self._connection_ready:
             yield self.maybe_connect()
-        LOGGER.debug('Publishing to %s->%s %r (Properties %r)', message,
-                     exchange, routing_key, properties)
+        LOGGER.debug('Publishing to %d bytes->%s %r (Properties %r)',
+                     len(message), exchange, routing_key, properties)
         self.channel.basic_publish(exchange, routing_key, message,
                                    pika.BasicProperties(**properties))
 


### PR DESCRIPTION
If logging was directed to an ASCII stream (e.g., stdout in some cases), then we were exploding with something like `UnicodeDecodeError: 'ascii' codec can't decode byte 0xaf in position 14: ordinal not in range(128)` when we logged the message body.  Probably shouldn't be doing that anyway, so I'll just log the number of bytes instead.
