### PR TITLE
Move from py_modules to package distributions.

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Version History
 ===============
 
+`0.1.3`_ Sept 28, 2015
+----------------------
+- Use packages instead of py_modules
+
 `0.1.2`_ Sept 25, 2015
 ----------------------
 - Don't log the message body
@@ -13,6 +17,7 @@ Version History
 ----------------------
  - Initial implementation
 
+.. _0.1.3: https://github.com/sprockets/sprockets.amqp/compare/0.1.2...0.1.3
 .. _0.1.2: https://github.com/sprockets/sprockets.amqp/compare/0.1.1...0.1.2
 .. _0.1.1: https://github.com/sprockets/sprockets.amqp/compare/0.1.0...0.1.1
 .. _0.1.0: https://github.com/sprockets/sprockets.amqp/compare/551982c...0.1.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='sprockets.mixins.amqp',
-    version='0.1.2',
+    version='0.1.3',
     description='Mixin for publishing events to RabbitMQ',
     long_description=open('README.rst').read(),
     url='https://github.com/sprockets/sprockets.mixins.amqp',
@@ -23,7 +23,7 @@ setuptools.setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
-    py_modules=['sprockets.mixins.amqp'],
+    packages=setuptools.find_packages(),
     namespace_packages=['sprockets', 'sprockets.mixins'],
     install_requires=open('requires/installation.txt').read(),
     zip_safe=True)

--- a/sprockets/mixins/amqp/__init__.py
+++ b/sprockets/mixins/amqp/__init__.py
@@ -22,7 +22,7 @@ from tornado import ioloop
 from tornado import locks
 from tornado import web
 
-version_info = (0, 1, 2)
+version_info = (0, 1, 3)
 __version__ = '.'.join(str(v) for v in version_info)
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Distributing using py_modules inside of a namespace package seems to be somewhat busted.  Though it isn't nearly as pretty, packages works reliably.
