### PR TITLE
Fix memory lead issue with tornado locking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,9 +37,18 @@ This examples demonstrates the most basic usage of ``sprockets.mixins.amqp``
 
    import json
 
-   from tornado import gen
-   from tornado import web
+   from tornado import gen, web
    from sprockets.mixins import amqp
+
+  def make_app(**settings):
+       application = web.Application(
+           [
+               web.url(r'/', RequestHandler),
+           ], **settings)
+
+       amqp.install(application)
+       return application
+
 
    class RequestHandler(amqp.PublishingMixin, web.RequestHandler):
 
@@ -48,6 +57,13 @@ This examples demonstrates the most basic usage of ``sprockets.mixins.amqp``
            body = {'request': self.request.path, 'args': args, 'kwargs': kwargs}
            yield self.amqp_publish('exchange', 'routing.key', json.dumps(body),
                                    {'content_type': 'application/json'})
+
+Settings
+^^^^^^^^
+
+:url: The AMQP url
+:timeout: The connect timeout, in seconds, if the connection when you try to publish.
+:connection_attempts: The maximum number of retry attempts in case of connection errors.
 
 Source
 ------

--- a/sprockets/mixins/amqp/__init__.py
+++ b/sprockets/mixins/amqp/__init__.py
@@ -138,7 +138,7 @@ class AMQP(object):
             parameters=self._parameters,
             on_open_callback=self._on_connection_open,
             on_open_error_callback=self._on_connection_open_error,
-            custom_ioloop=ioloop.IOLoop.current())
+            custom_ioloop=self._io_loop)
 
     @property
     def _parameters(self):
@@ -243,7 +243,7 @@ class AMQP(object):
             self._open_channel()
 
 
-def install(application, io_loop=None, **kwargs):
+def install(application, **kwargs):
     """Call this to install AMQP for the Tornado application."""
     if getattr(application, 'amqp', None) is not None:
         LOGGER.warning('AMQP is already installed')

--- a/sprockets/mixins/amqp/__init__.py
+++ b/sprockets/mixins/amqp/__init__.py
@@ -82,13 +82,17 @@ class AMQP(object):
         :param str routing_key: The routing key to publish with
         :param str message: The message body
         :param dict properties: The message properties
+        :raises pika.exceptions.ChannelClosed if the channel unexpectedly
+            closes when pika tries to publish.
+        :raises tornado.web.HTTPError if there is a timeout while trying
+            to connect to RabbitMQ. Sends a 504 response.
 
         """
         if not self._is_ready:
             LOGGER.info('Closed channel, waiting for %s secs',
                         self._timeout)
             yield self._connection_wait()
-        LOGGER.debug('Publishing to %d bytes to %s %r (Properties %r)',
+        LOGGER.debug('Publishing %d bytes to %s %r (Properties %r)',
                      len(message), exchange, routing_key, properties)
         self._channel.basic_publish(exchange, routing_key, message,
                                     pika.BasicProperties(**properties))

--- a/sprockets/mixins/amqp/__init__.py
+++ b/sprockets/mixins/amqp/__init__.py
@@ -10,13 +10,11 @@ Configured using two environment variables: ``AMQP_URL`` and ``AMQP_TIMEOUT``
 connecting to RabbitMQ.
 
 """
-import datetime
 import logging
 import os
 import pika
-import pika.exceptions
 
-from tornado import concurrent, gen, ioloop, locks, web
+from tornado import gen, ioloop, locks, web
 
 version_info = (0, 1, 4)
 __version__ = '.'.join(str(v) for v in version_info)
@@ -25,46 +23,11 @@ LOGGER = logging.getLogger(__name__)
 
 
 class PublishingMixin(object):
-    """The request handler will connect to RabbitMQ on the first request,
-    blocking until the connection and channel are established. If RabbitMQ
-    closes it's connection to the app at any point, a connection attempt will
-    be made on the next request.
-
-    This class implements a pattern for the use of a single AMQP connection
-    to RabbitMQ.
-
-    Expects the :envvar:`AMQP_URL` environment variable to construct
-    :class:`pika.connection.URLParameters`.
+    """This mixin adds publishing messages to RabbitMQ. It uses a
+    persistent connection and channel opened when the application
+    start up and automatically reopened if closed by RabbitMQ
 
     """
-
-    def initialize(self):
-        """Initialize the RequestHandler ensuring there is an AMQP object
-        associated with the application.
-
-        """
-        super(PublishingMixin, self).initialize()
-        if not hasattr(self.application, 'amqp'):
-            self.application.amqp = AMQP()
-
-    @gen.coroutine
-    def prepare(self):
-        """Prepare the handler, ensuring RabbitMQ is connected or start a new
-        connection attempt.
-
-        If a new connection needs to be created, this will wait until the
-        connection is established.
-
-        Waiting for a new connection will timeout after ``AMQP_TIMEOUT`` and
-        return a 504 error.
-
-        """
-        parent = super(PublishingMixin, self).prepare()
-        if concurrent.is_future(parent):
-            yield parent
-
-        if not self._finished:
-            yield self.application.amqp.maybe_connect()
 
     @gen.coroutine
     def amqp_publish(self, exchange, routing_key, message, properties):
@@ -81,34 +44,36 @@ class PublishingMixin(object):
 
 
 class AMQP(object):
-    """Object encapsulating all AMQP functionality"""
+    """Connect and maintain the connection to RabbitMQ. If RabbitMQ closes
+    the connection, it will be reopened. If the channel is closed, it will
+    indicate a problem with one of the commands, and will be reopened.
 
-    DEFAULT_URL = 'amqp://guest:guest@localhost:5672/%2f'
+    :param str url: The AMQP url
+    :param tornado.ioloop.IOLoop: The IOLoop to pass to pika.TornadoConnection
+        If this parameter is :data:`None`, then the active IOLoop,
+        as determined by :meth:`tornado.ioloop.IOLoop.instance`, is used.
+    :param int timeout: The connect timeout (seconds) in the event the
+        connection is closed at publish time.
+    :param int connection_attempts: The maximum number of retry attempts
+        when connection errors are encountered.
 
-    def __init__(self):
-        self.channel = None
-        self._connection = None
-        self._ready = locks.Event()
+    """
+    DEFAULT_TIMEOUT = 5
+    DEFAULT_CONNECTION_ATTEMPTS = 3
+    MAX_WAITING_SIZE = 10000
+
+    def __init__(self, url='amqp://guest:guest@localhost:5672/%2f',
+                 io_loop=None, timeout=DEFAULT_TIMEOUT,
+                 connnection_attempts=DEFAULT_CONNECTION_ATTEMPTS):
+        self._channel = None
+        self._amqp_url = url
+        self._io_loop = io_loop or ioloop.IOLoop.current()
+        self._timeout = timeout
+        self._connnection_attempts = int(connnection_attempts) or \
+            self.DEFAULT_CONNECTION_ATTEMPTS
+        self._condition = locks.Condition()
         self._connecting = False
-        self._timeout = datetime.timedelta(
-            seconds=int(os.environ.get('AMQP_TIMEOUT', 5)))
-
-    @gen.coroutine
-    def maybe_connect(self):
-        """Check and make sure that the RabbitMQ connection is established
-        and if not, create it.
-
-        """
-        # The connection is established, no need to do anything
-        if self._connection_is_ready:
-            return
-
-        # If not connecting, then try to connect as needed
-        elif not self._connecting:
-            self._connection = self._connect()
-
-        # The connection is not established yet, wait until it is or timeout
-        yield self._wait_for_connection()
+        self._connect()
 
     @gen.coroutine
     def publish(self, exchange, routing_key, message, properties):
@@ -120,68 +85,110 @@ class AMQP(object):
         :param dict properties: The message properties
 
         """
-        yield self.maybe_connect()
-        LOGGER.debug('Publishing to %d bytes->%s %r (Properties %r)',
+        if not self._is_ready:
+            LOGGER.info('Closed channel, waiting for %s secs',
+                        self._timeout)
+            yield self._connection_wait()
+        LOGGER.debug('Publishing to %d bytes to %s %r (Properties %r)',
                      len(message), exchange, routing_key, properties)
-        self.channel.basic_publish(exchange, routing_key, message,
-                                   pika.BasicProperties(**properties))
+        self._channel.basic_publish(exchange, routing_key, message,
+                                    pika.BasicProperties(**properties))
+
+    @property
+    def channel(self):
+        """Return the currently opened channel
+
+        :rtype pika.channel.Channel: The channel closed with RabbitMQ
+
+        """
+        return self._channel
 
     def _connect(self):
+        """Connects to RabbitMQ if the connection is closed"""
+        if self._connecting:
+            return
+        self._channel = None
+        self._connecting = True
+        self._connection = self._open_connection()
+
+    def _reconnect(self):
+        """Reconnect to RabbitMQ if the connection is closed and
+        not already connecting.
+
+        """
+        if self._connecting:
+            return
+        LOGGER.info('Reconnecting to %s', self._amqp_url)
+        self._io_loop.add_timeout(self._io_loop.time() + 0.1, self._connect)
+
+    def _open_connection(self):
         """This method connects to RabbitMQ, returning the connection handle.
         When the connection is established, the _on_connection_open method
-        will be invoked by pika.
+        will be invoked by pika. In the event the connection cannot be
+        opened, then the _on_connection_open_error is invoked.
 
         :rtype: pika.TornadoConnection
 
         """
-        LOGGER.info('Creating a new RabbitMQ connection')
-        self._connecting = True
-        self._ready.clear()
-        return pika.TornadoConnection(self._parameters,
-                                      self._on_connection_open,
-                                      self._on_connection_open_error,
-                                      custom_ioloop=ioloop.IOLoop.current())
+        LOGGER.info('Creating connection to %s', self._amqp_url)
+        return pika.TornadoConnection(
+            parameters=self._parameters,
+            on_open_callback=self._on_connection_open,
+            on_open_error_callback=self._on_connection_open_error,
+            custom_ioloop=ioloop.IOLoop.current())
 
     @property
-    def _connection_is_ready(self):
-        """Return True if the both the AMQP connection and channel are open
+    def _parameters(self):
+        """Return a pika URLParameters object using the AMQP url
+        which identifies the Rabbit MQ server as a URL ready for
+        :class:`pika.connection.URLParameters`.
 
-        :rtype: bool
+        :rtype: pika.URLParameters
 
         """
-        return self._connection_is_open and self._channel_is_open
+        parameters = pika.URLParameters(self._amqp_url)
+        if self._connnection_attempts > 0:
+            parameters.connection_attempts = self._connnection_attempts
+        return parameters
 
     @property
-    def _connection_is_open(self):
+    def _is_ready(self):
         """Returns ``True``if the connection to RabbitMQ is established and
         ready to use.
 
         :rtype: bool
 
         """
-        return self._connection and self._connection.is_open
+        return self._channel and self._channel.is_open
 
-    @property
-    def _channel_is_open(self):
-        """Returns ``True``if the connection to RabbitMQ is established and
-        ready to use.
-
-        :rtype: bool
-
-        """
-        return self.channel and self.channel.is_open
-
-    @staticmethod
-    def _connection_timeout():
-        """Invoked when a connection to RabbitMQ has timed out and we
-        want to return an error to the client.
-
-        :raises: tornado.web.HTTPError
-
-        """
+    @gen.coroutine
+    def _connection_wait(self):
+        """Wait for a pending AMQP connection to complete"""
+        waiting_size = len(self._condition._waiters)
+        if waiting_size < self.MAX_WAITING_SIZE:
+            ready = yield self._condition.wait(
+                timeout=self._io_loop.time() + self._timeout)
+            if ready:
+                raise gen.Return(ready)
+        else:
+            LOGGER.warning('Maximum waiting for AMQP connection is > %s (%s)',
+                           self.MAX_WAITING_SIZE, waiting_size)
+        self._reconnect()  # attempt reconnect
         raise web.HTTPError(504, 'AMQP connection timeout')
 
-    def _on_connection_close(self, _connection, reply_code, reply_text):
+    def _on_connection_open(self, _connection):
+        """This method is called by pika once the connection to RabbitMQ has
+        been established. It passes the handle to the connection object in
+        case we need it.
+
+        :param pika.TornadoConnection _connection: The AMQP connection object
+
+        """
+        LOGGER.debug('Connected to RabbitMQ, opening a channel')
+        self._connection.add_on_close_callback(self._on_connection_closed)
+        self._open_channel()
+
+    def _on_connection_closed(self, _connection, reply_code, reply_text):
         """This method is invoked by pika when the connection to RabbitMQ is
         closed unexpectedly. Since it is unexpected, we will reconnect to
         RabbitMQ if it disconnects.
@@ -193,43 +200,24 @@ class AMQP(object):
         """
         LOGGER.warning('RabbitMQ has disconnected (%s): %s, reconnecting',
                        reply_code, reply_text)
-        self.channel = None
-        self._connection = self._connect()
-
-    def _on_connection_open(self, _connection):
-        """This method is called by pika once the connection to RabbitMQ has
-        been established. It passes the handle to the connection object in
-        case we need it.
-
-        :param pika.TornadoConnection _connection: The AMQP connection object
-
-        """
-        LOGGER.debug('Connected to RabbitMQ, opening a channel')
-        self._connection.add_on_close_callback(self._on_connection_close)
-        self._open_channel()
+        self._connecting = False
+        self._connect()
 
     def _on_connection_open_error(self, *args, **kwargs):
-        """Called when RabbitMQ has been connected to.
-
-        :raises: tornado.web.HTTPError
-
-        """
-        LOGGER.debug('Error connecting to RabbitMQ: %r, %r', args, kwargs)
+        """Called when RabbitMQ has been connected to."""
+        LOGGER.debug('RabbitMQ connection error: (%r), %r, reconnecting',
+                     args, kwargs)
         self._connecting = False
-        self._ready.clear()
-        raise web.HTTPError(504, 'AMQP Connection Error')
+        self._reconnect()
 
     def _open_channel(self):
-        """Open a new channel with RabbitMQ by issuing the Channel.Open RPC
-        command. When RabbitMQ responds that the channel is open, the
-        _on_channel_open callback will be invoked by pika.
+        """Open a new channel with RabbitMQ by issuing the Channel.Open
+        RPC command. When RabbitMQ responds that the channel is open,
+        the _on_channel_open callback will be invoked by pika.
 
         """
         LOGGER.info('Creating a new channel')
-        self.channel = None
-        self._connecting = True
-        self._ready.clear()
-        self._connection.channel(self._on_channel_open)
+        self._connection.channel(on_open_callback=self._on_channel_open)
 
     def _on_channel_open(self, channel):
         """Called when the RabbitMQ accepts the channel open request.
@@ -237,13 +225,13 @@ class AMQP(object):
         :param pika.channel.Channel channel: The channel opened with RabbitMQ
 
         """
-        LOGGER.debug('AMQP channel opened')
-        self.channel = channel
-        self.channel.add_on_close_callback(self._on_channel_close)
+        LOGGER.debug('RabbitMQ channel opened')
+        self._channel = channel
+        self._channel.add_on_close_callback(self._on_channel_closed)
         self._connecting = False
-        self._ready.set()
+        self._condition.notify_all()
 
-    def _on_channel_close(self, channel, reply_code, reply_text):
+    def _on_channel_closed(self, channel, reply_code, reply_text):
         """Called when the RabbitMQ accepts the channel close request.
 
         :param pika.channel.Channel channel: The channel closed with RabbitMQ
@@ -254,24 +242,21 @@ class AMQP(object):
         LOGGER.warning('RabbitMQ closed the channel (%s): %s',
                        reply_code, reply_text)
         if not self._connecting:
-            LOGGER.info('Reopening RabbitMQ channel...')
+            self._channel = None
+            self._connecting = True
             self._open_channel()
 
-    @property
-    def _parameters(self):
-        """Return a pika URLParameters object using the :envvar:`AMQP_URL`
-        environment variable which identifies the Rabbit MQ server as a URL
-        ready for :class:`pika.connection.URLParameters`.
 
-        :rtype: pika.URLParameters
+def install(application, io_loop=None, **kwargs):
+    """Call this to install AMQP for the Tornado application."""
+    if getattr(application, 'amqp', None) is not None:
+        LOGGER.warning('AMQP is already installed')
+        return False
 
-        """
-        return pika.URLParameters(os.environ.get('AMQP_URL', self.DEFAULT_URL))
+    if os.environ.get('AMQP_TIMEOUT'):
+        kwargs['timeout'] = int(os.environ['AMQP_TIMEOUT'])
+    if os.environ.get('AMQP_URL'):
+        kwargs['url'] = os.environ['AMQP_URL']
 
-    @gen.coroutine
-    def _wait_for_connection(self):
-        """Wait for a pending AMQP connection to complete"""
-        try:
-            yield self._ready.wait(self._timeout)
-        except gen.TimeoutError:
-            self._connection_timeout()
+    setattr(application, 'amqp', AMQP(**kwargs))
+    return True


### PR DESCRIPTION
- Connect to AMQP on start and maintain a persistent connection
- Change to use tornado locks.Condition vs locks.Event
