### PR TITLE
Replace AMQP publisher internals with latest internal version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Release History
+
+## 2.0.0 (2017-04-20)
+- Move Mixin and AMQP client to separate files
+- Replace AMQP connection handling code with latest internal version
+- Provide ability to register callbacks for ready, unavailable, and persistent failure states
+- Remove default AMQP URL from AMQP class, url is now a required parameter for install
+- Rename amqp_publish 'message' parameter to 'body'
+- Add properties for all AMQP states
+- Provide mandatory AMQP properties (app_id, correlation_id, message_id, timestamp) automatically
+    - Mandatory properties cannot be overridden
+- Add unit test coverage for new functionality
+    - Test execution requires a running AMQP server
+
+## 0.1.0 (2015-09-08)
+- Initial release

--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -1,4 +1,5 @@
 coverage>=3.7,<4
 nose>=1.3.1,<2.0.0
+mock>=2.0.0,<3
 wheel
 -r installation.txt

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,31 @@
 #!/usr/bin/env python
-#
+import os.path
 
 import setuptools
 
+from sprockets.mixins.amqp import __version__
+
+
+def read_requirements(name):
+    requirements = []
+    try:
+        with open(os.path.join('requires', name)) as req_file:
+            for line in req_file:
+                if '#' in line:
+                    line = line[:line.index('#')]
+                line = line.strip()
+                if line.startswith('-r'):
+                    requirements.extend(read_requirements(line[2:].strip()))
+                elif line and not line.startswith('-'):
+                    requirements.append(line)
+    except IOError:
+        pass
+    return requirements
+
+
 setuptools.setup(
     name='sprockets.mixins.amqp',
-    version='1.0.1',
+    version=__version__,
     description='Mixin for publishing events to RabbitMQ',
     long_description=open('README.rst').read(),
     url='https://github.com/sprockets/sprockets.mixins.amqp',
@@ -28,5 +48,5 @@ setuptools.setup(
     ],
     packages=setuptools.find_packages(),
     namespace_packages=['sprockets', 'sprockets.mixins'],
-    install_requires=open('requires/installation.txt').read(),
+    install_requires=read_requirements('installation.txt'),
     zip_safe=True)

--- a/sprockets/mixins/amqp/__init__.py
+++ b/sprockets/mixins/amqp/__init__.py
@@ -1,258 +1,58 @@
-"""The PublishingMixin wraps RabbitMQ use into a request handler, with
-methods to speed the development of publishing RabbitMQ messages.
+"""The PublishingMixin adds RabbitMQ publishing capabilities to a request
+handler, with methods to speed the development of publishing RabbitMQ messages.
 
-Configured using two environment variables: ``AMQP_URL`` and ``AMQP_TIMEOUT``
+Configured using the following environment variables:
 
-``AMQP_URL`` is the AMQP url to connect to, defaults to
-``amqp://guest:guest@localhost:5672/%2f``.
-
-``AMQP_TIMEOUT`` is the number of seconds to wait until timing out when
-connecting to RabbitMQ.
-
+    ``AMQP_URL`` - The AMQP URL to connect to.
+    ``AMQP_TIMEOUT`` - The optional maximum time to wait for a bad state
+                       to resolve before treating the failure as
+                       persistent.
+    ``AMQP_RECONNECT_DELAY`` - The optional time in seconds to wait before
+                               reconnecting on connection failure.
+    ``AMQP_CONNECTION_ATTEMPTS`` - The optional number of connection
+                                   attempts to make before giving up.
 """
-import logging
 import os
-import pika
-
-from tornado import gen, ioloop, locks, web
-
-version_info = (1, 0, 1)
-__version__ = '.'.join(str(v) for v in version_info)
+import logging
 
 LOGGER = logging.getLogger(__name__)
 
+try:
+    from .mixins import PublishingMixin
+    from .amqp import AMQP
 
-class PublishingMixin(object):
-    """This mixin adds publishing messages to RabbitMQ. It uses a
-    persistent connection and channel opened when the application
-    start up and automatically reopened if closed by RabbitMQ
+except ImportError as error:
+    class PublishingMixin(object):
+        def __init__(self, *args, **kwargs):
+            raise error
 
-    """
+    class AMQP(object):
+        def __init__(self, *args, **kwargs):
+            raise error
 
-    @gen.coroutine
-    def amqp_publish(self, exchange, routing_key, message, properties):
-        """Publish the message to RabbitMQ
-
-        :param str exchange: The exchange to publish to
-        :param str routing_key: The routing key to publish with
-        :param str message: The message body
-        :param dict properties: The message properties
-
-        """
-        yield self.application.amqp.publish(exchange, routing_key, message,
-                                            properties)
-
-
-class AMQP(object):
-    """Connect and maintain the connection to RabbitMQ. If RabbitMQ closes
-    the connection, it will be reopened. If the channel is closed, it will
-    indicate a problem with one of the commands, and will be reopened.
-
-    :param str url: The AMQP url
-    :param tornado.ioloop.IOLoop: The IOLoop to pass to pika.TornadoConnection
-        If this parameter is :data:`None`, then the active IOLoop,
-        as determined by :meth:`tornado.ioloop.IOLoop.instance`, is used.
-    :param int timeout: The connect timeout (seconds) in the event the
-        connection is closed at publish time.
-    :param int connection_attempts: The maximum number of retry attempts
-        when connection errors are encountered.
-
-    """
-    DEFAULT_TIMEOUT = 5
-    DEFAULT_CONNECTION_ATTEMPTS = 3
-
-    def __init__(self, url='amqp://guest:guest@localhost:5672/%2f',
-                 io_loop=None, timeout=DEFAULT_TIMEOUT,
-                 connnection_attempts=DEFAULT_CONNECTION_ATTEMPTS):
-        self._channel = None
-        self._amqp_url = url
-        self._io_loop = io_loop or ioloop.IOLoop.current()
-        self._timeout = timeout
-        self._connnection_attempts = int(connnection_attempts) or \
-            self.DEFAULT_CONNECTION_ATTEMPTS
-        self._condition = locks.Condition()
-        self._connecting = False
-        self._connect()
-
-    @gen.coroutine
-    def publish(self, exchange, routing_key, message, properties):
-        """Publish the message to RabbitMQ
-
-        :param str exchange: The exchange to publish to
-        :param str routing_key: The routing key to publish with
-        :param str message: The message body
-        :param dict properties: The message properties
-        :raises pika.exceptions.ChannelClosed if the channel unexpectedly
-            closes when pika tries to publish.
-        :raises tornado.web.HTTPError if there is a timeout while trying
-            to connect to RabbitMQ. Sends a 504 response.
-
-        """
-        if not self._is_ready:
-            LOGGER.info('Closed channel, waiting for %s secs',
-                        self._timeout)
-            yield self._connection_wait()
-        LOGGER.debug('Publishing %d bytes to %s %r (Properties %r)',
-                     len(message), exchange, routing_key, properties)
-        self._channel.basic_publish(exchange, routing_key, message,
-                                    pika.BasicProperties(**properties))
-
-    @property
-    def channel(self):
-        """Return the currently opened channel
-
-        :rtype pika.channel.Channel: The channel closed with RabbitMQ
-
-        """
-        return self._channel
-
-    def _connect(self):
-        """Connects to RabbitMQ if the connection is closed"""
-        if self._connecting:
-            return
-        self._channel = None
-        self._connecting = True
-        self._connection = self._open_connection()
-
-    def _reconnect(self):
-        """Reconnect to RabbitMQ if the connection is closed and
-        not already connecting.
-
-        """
-        if self._connecting:
-            return
-        LOGGER.info('Reconnecting to %s', self._amqp_url)
-        self._io_loop.add_timeout(self._io_loop.time() + 0.1, self._connect)
-
-    def _open_connection(self):
-        """This method connects to RabbitMQ, returning the connection handle.
-        When the connection is established, the _on_connection_open method
-        will be invoked by pika. In the event the connection cannot be
-        opened, then the _on_connection_open_error is invoked.
-
-        :rtype: pika.TornadoConnection
-
-        """
-        LOGGER.info('Creating connection to %s', self._amqp_url)
-        return pika.TornadoConnection(
-            parameters=self._parameters,
-            on_open_callback=self._on_connection_open,
-            on_open_error_callback=self._on_connection_open_error,
-            custom_ioloop=self._io_loop)
-
-    @property
-    def _parameters(self):
-        """Return a pika URLParameters object using the AMQP url
-        which identifies the Rabbit MQ server as a URL ready for
-        :class:`pika.connection.URLParameters`.
-
-        :rtype: pika.URLParameters
-
-        """
-        parameters = pika.URLParameters(self._amqp_url)
-        if self._connnection_attempts > 0:
-            parameters.connection_attempts = self._connnection_attempts
-        return parameters
-
-    @property
-    def _is_ready(self):
-        """Returns ``True``if the connection to RabbitMQ is established and
-        ready to use.
-
-        :rtype: bool
-
-        """
-        return self._channel and self._channel.is_open
-
-    @gen.coroutine
-    def _connection_wait(self):
-        """Wait for a pending AMQP connection to complete"""
-        ready = yield self._condition.wait(
-            timeout=self._io_loop.time() + self._timeout)
-        if not ready:
-            raise web.HTTPError(504, 'AMQP connection timeout')
-
-    def _on_connection_open(self, _connection):
-        """This method is called by pika once the connection to RabbitMQ has
-        been established. It passes the handle to the connection object in
-        case we need it.
-
-        :param pika.TornadoConnection _connection: The AMQP connection object
-
-        """
-        LOGGER.debug('Connected to RabbitMQ, opening a channel')
-        self._connection.add_on_close_callback(self._on_connection_closed)
-        self._open_channel()
-
-    def _on_connection_closed(self, _connection, reply_code, reply_text):
-        """This method is invoked by pika when the connection to RabbitMQ is
-        closed unexpectedly. Since it is unexpected, we will reconnect to
-        RabbitMQ if it disconnects.
-
-        :param pika.TornadoConnection _connection: The AMQP connection object
-        :param int reply_code: The code for the disconnect
-        :param str reply_text: The disconnect reason
-
-        """
-        LOGGER.warning('RabbitMQ has disconnected (%s): %s, reconnecting',
-                       reply_code, reply_text)
-        self._connecting = False
-        self._connect()
-
-    def _on_connection_open_error(self, *args, **kwargs):
-        """Called when RabbitMQ has been connected to."""
-        LOGGER.debug('RabbitMQ connection error: (%r), %r, reconnecting',
-                     args, kwargs)
-        self._connecting = False
-        self._reconnect()
-
-    def _open_channel(self):
-        """Open a new channel with RabbitMQ by issuing the Channel.Open
-        RPC command. When RabbitMQ responds that the channel is open,
-        the _on_channel_open callback will be invoked by pika.
-
-        """
-        LOGGER.info('Creating a new channel')
-        self._connection.channel(on_open_callback=self._on_channel_open)
-
-    def _on_channel_open(self, channel):
-        """Called when the RabbitMQ accepts the channel open request.
-
-        :param pika.channel.Channel channel: The channel opened with RabbitMQ
-
-        """
-        LOGGER.debug('RabbitMQ channel opened')
-        self._channel = channel
-        self._channel.add_on_close_callback(self._on_channel_closed)
-        self._connecting = False
-        self._condition.notify_all()
-
-    def _on_channel_closed(self, channel, reply_code, reply_text):
-        """Called when the RabbitMQ accepts the channel close request.
-
-        :param pika.channel.Channel channel: The channel closed with RabbitMQ
-        :param int reply_code: The code for the disconnect
-        :param str reply_text: The disconnect reason
-
-        """
-        LOGGER.warning('RabbitMQ closed the channel (%s): %s',
-                       reply_code, reply_text)
-        if not self._connecting:
-            self._channel = None
-            self._connecting = True
-            self._open_channel()
+version_info = (2, 0, 0)
+__version__ = '.'.join(str(v) for v in version_info)
 
 
 def install(application, **kwargs):
-    """Call this to install AMQP for the Tornado application."""
+    """Call this to install AMQP for the Tornado application.
+
+    :rtype: bool
+
+    """
     if getattr(application, 'amqp', None) is not None:
         LOGGER.warning('AMQP is already installed')
         return False
 
-    if os.environ.get('AMQP_TIMEOUT'):
-        kwargs['timeout'] = int(os.environ['AMQP_TIMEOUT'])
     if os.environ.get('AMQP_URL'):
         kwargs['url'] = os.environ['AMQP_URL']
+    if os.environ.get('AMQP_TIMEOUT'):
+        kwargs['timeout'] = int(os.environ['AMQP_TIMEOUT'])
+    if os.environ.get('AMQP_RECONNECT_DELAY'):
+        kwargs['reconnect_delay'] = int(os.environ['AMQP_RECONNECT_DELAY'])
+    if os.environ.get('AMQP_CONNECTION_ATTEMPTS'):
+        kwargs['connection_attempts'] = int(
+            os.environ['AMQP_CONNECTION_ATTEMPTS'])
 
     setattr(application, 'amqp', AMQP(**kwargs))
     return True

--- a/sprockets/mixins/amqp/amqp.py
+++ b/sprockets/mixins/amqp/amqp.py
@@ -1,0 +1,455 @@
+import logging
+import multiprocessing
+import os
+import time
+import uuid
+
+from tornado import gen, ioloop, locks, web
+import pika
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AMQP(object):
+    """This class encompasses all of the AMQP/RabbitMQ specific behaviors.
+
+    If RabbitMQ closes the connection, it will reopen it. You should
+    look at the output, as there are limited reasons why the connection may
+    be closed, which usually are tied to permission related issues or
+    socket timeouts.
+
+    If the channel is closed, it will indicate a problem with one of the
+    commands that were issued and that should surface in the output as well.
+
+    """
+    DEFAULT_TIMEOUT = 10
+    DEFAULT_RECONNECT_DELAY = 5
+    DEFAULT_CONNECTION_ATTEMPTS = 3
+
+    STATE_IDLE = 0x01
+    STATE_CONNECTING = 0x02
+    STATE_CONNECTED = 0x03
+    STATE_CLOSING = 0x04
+    STATE_CLOSED = 0x05
+    STATE_BLOCKED = 0x06
+
+    def __init__(self,
+                 url,
+                 timeout=None,
+                 reconnect_delay=None,
+                 connection_attempts=None,
+                 on_ready_callback=None,
+                 on_unavailable_callback=None,
+                 on_persistent_failure_callback=None,
+                 on_message_returned_callback=None,
+                 io_loop=None):
+        """Create a new instance of the consumer class, passing in the AMQP
+        URL used to connect to RabbitMQ.
+
+        :param str url: The AMQP URL to connect to.
+        :param int timeout: The optional maximum time to wait for a bad state
+                    to resolve before treating the failure as
+                    persistent.
+        :param int reconnect_delay: The optional time in seconds to wait before
+                                    reconnecting on connection failure.
+        :param int connection_attempts: The optional number of connection
+                                        attempts to make before giving up.
+        :param callable on_ready_callback: The optional callback to call when
+                                           the connection to the AMQP server
+                                           has been established and is ready.
+        :param callable on_unavailable_callback: The optional callback to call
+                                                 when the connection to the
+                                                 AMQP server becomes
+                                                 unavailable.
+        :param callable on_persistent_failure_callback: The optional callback
+                                                        to call when the
+                                                        connection failure does
+                                                        not resolve itself
+                                                        within the timeout.
+        :param callable on_message_returned_callback: The optional callback
+                                                      to call when the AMQP
+                                                      server returns a message.
+        :param tornado.ioloop.IOLoop io_loop: An optional IOLoop to override
+                                              the default with.
+
+        :raises AttributeError: If timeout <= reconnect_delay
+
+        """
+        self._channel = None
+        self._ioloop = ioloop.IOLoop.current(io_loop)
+        self._on_ready = on_ready_callback
+        self._on_unavailable = on_unavailable_callback
+        self._on_persistent_failure = on_persistent_failure_callback
+        self.on_message_returned = on_message_returned_callback
+        self._reconnect_delay = reconnect_delay or self.DEFAULT_RECONNECT_DELAY
+        self._timeout = timeout or self.DEFAULT_TIMEOUT
+        self._connection_attempts = (connection_attempts or
+                                     self.DEFAULT_CONNECTION_ATTEMPTS)
+        self._schemas = {}
+        self._state = self.STATE_IDLE
+        self._url = url
+        self._ready_condition = locks.Condition()
+
+        if self._timeout <= self._reconnect_delay:
+            raise AttributeError('Reconnection must be less than timeout')
+
+        # Automatically start the RabbitMQ connection on creation
+        self._connection = self.connect()
+
+    @gen.coroutine
+    def publish(self, exchange, routing_key, body,
+                app_id=None, correlation_id=None, properties=None,
+                mandatory=False):
+        """Publish a message to RabbitMQ. If the RabbitMQ connection is not
+        established or is blocked, attempt to wait until sending is possible.
+
+        :param str exchange: The exchange to publish the message to.
+        :param str routing_key: The routing key to publish the message with.
+        :param bytes body: The message body to send.
+        :param str app_id: The ID of the app sending the message.
+        :param str correlation_id: The correlation ID associated
+                                   with the message.
+        :param dict properties: An optional dict of additional properties
+                                to append. Will not override mandatory
+                                properties:
+                                app_id, correlation_id, message_id, timestamp
+        :param bool mandatory: Whether to instruct the server to return an
+                               unqueueable message. Default False.
+                               http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish.mandatory
+
+        """
+        if not self.connected:
+            LOGGER.warning('AMQP connection not ready, waiting for ready')
+
+            ready = yield self._ready_condition.wait(
+                timeout=self._ioloop.time() + self._timeout)
+
+            if not ready:
+                LOGGER.error('AMQP connection did not establish within '
+                             'the timeout (%i seconds)', self._timeout)
+
+                if self._on_persistent_failure:
+                    self._on_persistent_failure(self, exchange, routing_key,
+                                                body, properties, mandatory)
+                else:
+                    raise web.HTTPError(504, 'AMQP connection timeout')
+
+        if self.connected:
+            if not app_id:
+                app_id = '{}/{}'.format(multiprocessing.current_process().name,
+                                        os.getpid())
+            # Set mandatory AMQP properties
+            properties = properties or {}
+            properties['app_id'] = app_id
+            properties['correlation_id'] = correlation_id
+            properties['message_id'] = str(uuid.uuid4())
+            properties['timestamp'] = int(time.time())
+
+            LOGGER.debug('Publishing %d bytes to %s %r (Properties %r)',
+                         len(body), exchange, routing_key, properties)
+
+            self._channel.basic_publish(
+                exchange,
+                routing_key,
+                body,
+                pika.BasicProperties(**properties),
+                mandatory
+            )
+
+    @property
+    def idle(self):
+        """Returns ``True`` if the connection to RabbitMQ is closing.
+
+        :rtype: bool
+
+        """
+        return self._state == self.STATE_IDLE
+
+    @property
+    def connecting(self):
+        """Returns ``True`` if the connection to RabbitMQ is open and a
+        channel is in the process of connecting.
+
+        :rtype: bool
+
+        """
+        return self._state == self.STATE_CONNECTING
+
+    @property
+    def connected(self):
+        """Returns ``True`` if the connection to RabbitMQ is connected.
+
+        :rtype: bool
+
+        """
+        return self._state == self.STATE_CONNECTED
+
+    @property
+    def blocked(self):
+        """Returns ``True`` if the connection is blocked by RabbitMQ.
+
+        :rtype: bool
+
+        """
+        return self._state == self.STATE_BLOCKED
+
+    @property
+    def closing(self):
+        """Returns ``True`` if the connection to RabbitMQ is closing.
+
+        :rtype: bool
+
+        """
+        return self._state == self.STATE_CLOSING
+
+    @property
+    def closed(self):
+        """Returns ``True`` if the connection to RabbitMQ is closed.
+
+        :rtype: bool
+
+        """
+        return self._state == self.STATE_CLOSED
+
+    @property
+    def ready(self):
+        """Returns ``True`` if the connection to RabbitMQ is established and
+        we can publish to it.
+
+        :rtype: bool
+
+        """
+        return self._state in (self.STATE_CONNECTED, self.STATE_BLOCKED)
+
+    @property
+    def channel(self):
+        """Return the currently opened channel
+
+        :rtype pika.channel.Channel: The channel open with RabbitMQ
+
+        """
+        return self._channel
+
+    @property
+    def _parameters(self):
+        """Return a pika URLParameters object using the AMQP url
+        which identifies the Rabbit MQ server as a URL ready for
+        :class:`pika.connection.URLParameters`.
+
+        :rtype: pika.URLParameters
+
+        """
+        parameters = pika.URLParameters(self._url)
+        if self._connection_attempts > 0:
+            parameters.connection_attempts = self._connection_attempts
+        return parameters
+
+    def connect(self):
+        """This method connects to RabbitMQ, returning the connection handle.
+        When the connection is established, the on_connection_open method
+        will be invoked by pika.
+
+        :rtype: pika.TornadoConnection
+
+        """
+        LOGGER.debug('Connecting to %s', self._url)
+        return pika.TornadoConnection(
+            parameters=self._parameters,
+            on_open_callback=self._on_connection_open,
+            on_open_error_callback=self._on_connection_open_error,
+            on_close_callback=self._on_connection_closed,
+            custom_ioloop=self._ioloop)
+
+    def close(self):
+        """Cleanly shutdown the connection to RabbitMQ
+
+        """
+        LOGGER.debug('Stopping')
+        if not self.ready and not self.connecting:
+            LOGGER.error('Closed called while not connected (%s)', self._state)
+            return
+        self._state = self.STATE_CLOSING
+        if self._on_unavailable:
+            self._on_unavailable(self)
+        LOGGER.info('Closing RabbitMQ connection')
+        self._connection.close()
+
+    def _reconnect(self):
+        """Schedule the next connection attempt if the class is not currently
+        closing.
+
+        """
+        if self._state != self.STATE_CLOSING:
+            LOGGER.debug('Attempting RabbitMQ reconnect in %s seconds',
+                         self._reconnect_delay)
+
+            def reconnect():
+                """Will be invoked by the IOLoop when it is time to reconnect.
+
+                """
+                if self._state != self.STATE_CLOSING:
+                    self._connection = self.connect()
+
+            self._ioloop.call_later(self._reconnect_delay, reconnect)
+        else:
+            LOGGER.warning('Cowardly refusing to reconnect due to the current '
+                           'object state: %s', self._state)
+
+    """
+    Connection event callbacks
+    """
+
+    def _on_connection_open(self, conn):
+        """This method is called by pika once the connection to RabbitMQ has
+        been established.
+
+        :type conn: pika.TornadoConnection
+
+        """
+        LOGGER.debug('Connection opened')
+        conn.add_on_connection_blocked_callback(self._on_connection_blocked)
+        conn.add_on_connection_unblocked_callback(
+            self._on_connection_unblocked)
+        self._channel = self._open_channel()
+
+    def _on_connection_open_error(self, _connection, error):
+        """Invoked if the connection to RabbitMQ can not be made.
+
+        :type _connection: pika.TornadoConnection
+        :param Exception error: The exception indicating failure
+
+        """
+        LOGGER.critical('Could not connect to RabbitMQ: %r', error)
+        self._reconnect()
+
+    def _on_connection_blocked(self, blocked):
+        """This method is called by pika if RabbitMQ sends a connection blocked
+        method, to let us know we need to throttle our publishing.
+
+        :param pika.spec.Connection.Blocked blocked: The blocked method obj
+
+        """
+        LOGGER.warning('Connection blocked: %s', blocked.reason)
+        self._state = self.STATE_BLOCKED
+        if self._on_unavailable:
+            self._on_unavailable(self)
+
+    def _on_connection_unblocked(self, _unblocked):
+        """When RabbitMQ indicates the connection is unblocked, set the state
+        appropriately.
+
+        :param pika.spec.Connection.Unblocked _unblocked: Unblocked method obj
+
+        """
+        LOGGER.debug('Connection unblocked')
+        self._state = self.STATE_CONNECTED
+        if self._on_ready:
+            self._on_ready(self)
+
+    def _on_connection_closed(self, _connection, reply_code, reply_text):
+        """This method is invoked by pika when the connection to RabbitMQ is
+        closed unexpectedly. Since it is unexpected, we will reconnect to
+        RabbitMQ if it disconnects.
+
+        :param pika.TornadoConnection _connection: Closed connection
+        :param int reply_code: The server provided reply_code if given
+        :param str reply_text: The server provided reply_text if given
+
+        """
+        self._connection = None
+        self._channel = None
+        self._state = self.STATE_CLOSED
+        if self._on_unavailable:
+            self._on_unavailable(self)
+        if self._state != self.STATE_CLOSING:
+            LOGGER.warning('Connection to RabbitMQ closed (%s): %s',
+                           reply_code, reply_text)
+            self._reconnect()
+
+    """
+    Channel event callbacks
+    """
+
+    def _open_channel(self):
+        """Open a new channel with RabbitMQ.
+
+        :rtype: pika.channel.Channel
+
+        """
+        LOGGER.debug('Creating a new channel')
+        self._state = self.STATE_CONNECTING
+        return self._connection.channel(self._on_channel_open)
+
+    def _on_channel_open(self, channel):
+        """This method is invoked by pika when the channel has been opened.
+        The channel object is passed in so we can make use of it.
+
+        :param pika.channel.Channel channel: The channel object
+
+        """
+        LOGGER.debug('Channel opened')
+        self._state = self.STATE_CONNECTED
+        self._channel = channel
+        self._channel.add_on_close_callback(self._on_channel_closed)
+        self._channel.add_on_flow_callback(self._on_channel_flow)
+        self._channel.add_on_return_callback(self._on_message_returned)
+        if self._on_ready:
+            self._on_ready(self)
+        self._ready_condition.notify_all()
+
+    def _on_channel_closed(self, channel, reply_code, reply_text):
+        """Invoked by pika when RabbitMQ unexpectedly closes the channel.
+
+        Channels are usually closed if you attempt to do something that
+        violates the protocol, such as re-declare an exchange or queue with
+        different parameters.
+
+        In this case, we just want to log the error and create a new channel
+        after setting the state back to connecting.
+
+        :param pika.channel.Channel channel: The closed channel
+        :param int reply_code: The numeric reason the channel was closed
+        :param str reply_text: The text reason the channel was closed
+
+        """
+        LOGGER.warning('Channel %i was closed: (%s) %s',
+                       channel, reply_code, reply_text)
+        if self._on_unavailable:
+            self._on_unavailable(self)
+        self._channel = self._open_channel()
+
+    def _on_channel_flow(self, method):
+        """When RabbitMQ indicates the connection is unblocked, set the state
+        appropriately.
+
+        :param pika.spec.Channel.Flow method: The Channel flow frame
+
+        """
+        if method.active:
+            LOGGER.warning('Channel flow enabled')
+            self._state = self.STATE_CONNECTED
+            if self._on_ready:
+                self._on_ready(self)
+        else:
+            LOGGER.info('Channel flow disabled')
+            self._state = self.STATE_BLOCKED
+            if self._on_unavailable:
+                self._on_unavailable(self)
+
+    def _on_message_returned(self, channel, method, properties, body):
+        """Log a returned AMQP message.
+
+        :param pika.channel.Channel channel: The channel object
+        :param pika.spec.Basic.Return method: The method object
+        :param pika.spec.BasicProperties properties: The message properties
+        :param str, unicode, bytes body: The message body
+
+        """
+        LOGGER.critical('%s message %s published to %s (CID %s) returned: %s',
+                        method.exchange, properties.message_id,
+                        method.routing_key, properties.correlation_id,
+                        method.reply_text)
+
+        if self.on_message_returned:
+            self.on_message_returned(self, method, properties, body)

--- a/sprockets/mixins/amqp/mixins.py
+++ b/sprockets/mixins/amqp/mixins.py
@@ -1,0 +1,55 @@
+import logging
+
+from tornado import gen
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PublishingMixin(object):
+    """This mixin adds publishing messages to RabbitMQ. It uses a
+    persistent connection and channel opened when the application
+    start up and automatically reopened if closed by RabbitMQ
+
+    """
+    @property
+    def app_id(self):
+        """Return a value to be used for the app_id AMQP message property.
+
+        :rtype: str
+
+        """
+        service = self.application.settings.get('service')
+        version = self.application.settings.get('version')
+        return '{}/{}'.format(service, version)
+
+    @gen.coroutine
+    def amqp_publish(self, exchange, routing_key, body, properties=None,
+                     mandatory=False):
+        """Publish the message to RabbitMQ
+
+        Expects Correlation ID to be available via self.correlation_id,
+        default value will be None if not set.
+        The ``sprockets.mixins.correlation`` plugin provides this.
+
+        :param str exchange: The exchange to publish the message to
+        :param str routing_key: The routing key to publish the message with
+        :param str,unicode,bytes body: The message body to send
+        :param dict properties: An optional dict of additional properties
+                                to append. Will not override mandatory
+                                properties:
+                                app_id, correlation_id, message_id, timestamp
+        :param bool mandatory: Whether to instruct the server to return an
+                               unqueueable message
+                               http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish.mandatory
+
+        """
+        yield self.application.amqp.publish(
+            exchange,
+            routing_key,
+            body,
+            self.app_id,
+            getattr(self, 'correlation_id', None),
+            properties,
+            mandatory
+        )

--- a/tests.py
+++ b/tests.py
@@ -1,16 +1,34 @@
 import logging
+import os
+import multiprocessing
 import uuid
 
 from pika import spec
-
-from tornado import gen
-from tornado import locks
-from tornado import testing
+from tornado import gen, locks, testing, web
+import mock
 
 from sprockets.mixins import amqp
 
+PIKA_BLOCKED_PATH = 'pika.spec.Connection.Blocked'
+PIKA_UNBLOCKED_PATH = 'pika.spec.Connection.Unblocked'
+PIKA_FLOW_PATH = 'pika.spec.Channel.Flow'
+PIKA_CHANNEL_PATH = 'pika.channel.Channel'
+PIKA_METHOD_PATH = 'pika.spec.Basic.Return'
+PIKA_PROPERTIES_PATH = 'pika.spec.BasicProperties'
+
+# Set this URL to that of a running AMQP server before executing tests
+if 'TEST_AMQP_URL' in os.environ:
+    AMQP_URL = os.environ['TEST_AMQP_URL']
+else:
+    AMQP_URL = 'amqp://guest:guest@localhost:5672/%2f'
 
 LOGGER = logging.getLogger(__name__)
+
+
+class TestRequestHandler(amqp.PublishingMixin):
+    def __init__(self, application):
+        self.application = application
+        self.correlation_id = str(uuid.uuid4())
 
 
 class BaseTestCase(testing.AsyncTestCase):
@@ -20,71 +38,507 @@ class BaseTestCase(testing.AsyncTestCase):
         super(BaseTestCase, self).setUp()
 
         # make sure that our logging statements get executed
-        amqp.LOGGER.enabled = True
-        amqp.LOGGER.setLevel(logging.DEBUG)
+        amqp.amqp.LOGGER.enabled = True
+        amqp.amqp.LOGGER.setLevel(logging.DEBUG)
+        amqp.mixins.LOGGER.enabled = True
+        amqp.mixins.LOGGER.setLevel(logging.DEBUG)
 
         self.exchange = str(uuid.uuid4())
         self.queue = str(uuid.uuid4())
         self.routing_key = str(uuid.uuid4())
-        self.ready = locks.Event()
-        self.get_response = locks.Event()
+        self.correlation_id = str(uuid.uuid4())
         self.message = None
-
+        self.test_queue_bound = locks.Event()
+        self.get_response = locks.Event()
+        self.amqp_ready = locks.Event()
         self.condition = locks.Condition()
-        amqp.install(self, io_loop=self.io_loop)
+        self.config = {
+            "url": AMQP_URL,
+            "reconnect_delay": 1,
+            "timeout": 2,
+            "on_ready_callback": self.on_ready,
+            "on_unavailable_callback": self.on_unavailable,
+            "on_persistent_failure_callback": self.on_persistent_failure,
+            "on_message_returned_callback": self.on_message_returned,
+            "io_loop": self.io_loop,
+        }
+        self.app = web.Application()
+        self.app.settings = {
+            'service': 'unit_tests',
+            'version': '0.0'
+        }
+        self.handler = TestRequestHandler(self.app)
+
+        self.clear_event_tracking()
+
+        amqp.install(self.app, **self.config)
         yield self.condition.wait(self.io_loop.time() + 5)
 
         LOGGER.info('Connected to RabbitMQ, declaring exchange %s',
                     self.exchange)
-        self.amqp.channel.exchange_declare(self.on_exchange_declare_ok,
-                                           self.exchange,
-                                           auto_delete=True)
+        self.app.amqp.channel.exchange_declare(self.on_exchange_declare_ok,
+                                               self.exchange,
+                                               auto_delete=True)
 
     def on_exchange_declare_ok(self, _method):
-        LOGGER.info('Exchange %s declared, declaring queue %s', self.exchange,
-                    self.queue)
-        self.amqp.channel.queue_declare(self.on_queue_declare_ok,
-                                        queue=self.queue,
-                                        auto_delete=True)
+        LOGGER.info(
+            'Exchange %s declared, declaring queue %s',
+            self.exchange,
+            self.queue
+        )
+        self.app.amqp.channel.queue_declare(self.on_queue_declare_ok,
+                                            queue=self.queue,
+                                            auto_delete=True)
 
     def on_queue_declare_ok(self, _method):
         LOGGER.info('Queue %s declared', self.queue)
-        self.amqp.channel.queue_bind(self.on_bind_ok, self.queue, self.exchange,
-                                     self.routing_key)
+        self.app.amqp.channel.queue_bind(self.on_bind_ok, self.queue,
+                                         self.exchange, self.routing_key)
 
     def on_bind_ok(self, _method):
         LOGGER.info('Queue %s bound to %s', self.queue, self.exchange)
-        self.amqp.channel.add_callback(self.on_get_response,
-                                       [spec.Basic.GetEmpty], False)
-        self.ready.set()
+        self.app.amqp.channel.add_callback(self.on_get_response,
+                                           [spec.Basic.GetEmpty], False)
+        self.test_queue_bound.set()
 
     def on_get_response(self, channel, method, properties=None, body=None):
         LOGGER.info('get_response: %r', method)
-        self.message = method, properties, body
+        self.message = {
+            'method': method,
+            'properties': properties,
+            'body': body,
+        }
         self.get_response.set()
+
+    def on_ready(self, caller):
+        LOGGER.info('on_ready called')
+        self.ready_called = True
+        self.amqp_ready.set()
+
+    def on_unavailable(self, caller):
+        LOGGER.info('on_unavailable called')
+        self.unavailable_called = True
+        self.amqp_ready.clear()
+
+    def on_persistent_failure(self, caller, exchange, routing_key,
+                              body, properties, mandatory):
+        LOGGER.info('on_persistent_failure called')
+        self.persistent_failure_called = True
+        self.failed_message = {
+            'exchange': exchange,
+            'routing_key': routing_key,
+            'body': body,
+            'properties': properties,
+        }
+        self.amqp_ready.clear()
+
+    def on_message_returned(self, caller, method, properties, body):
+        LOGGER.info('on_message_returned called')
+        self.message_returned_called = True
+        self.message_returned_error = method.reply_text
+        self.returned_message = {
+            'exchange': method.exchange,
+            'routing_key': method.routing_key,
+            'body': body,
+            'properties': properties,
+        }
+
+    def clear_event_tracking(self):
+        self.ready_called = False
+        self.unavailable_called = False
+        self.persistent_failure_called = False
+        self.message_returned_called = False
+        self.message_returned_error = None
+        self.failed_message = {
+            'exchange': None,
+            'routing_key': None,
+            'body': None,
+            'properties': None,
+        }
+        self.returned_message = {
+            'exchange': None,
+            'routing_key': None,
+            'body': None,
+            'properties': None,
+        }
 
     @gen.coroutine
     def get_message(self):
         self.message = None
         self.get_response.clear()
-        self.amqp.channel.basic_get(self.on_get_response, self.queue)
+        self.app.amqp.channel.basic_get(self.on_get_response, self.queue)
 
         LOGGER.info('Waiting on get')
         yield self.get_response.wait()
-        if isinstance(self.message[0], spec.Basic.GetEmpty):
+        if isinstance(self.message['method'], spec.Basic.GetEmpty):
             raise ValueError('Basic.GetEmpty')
         raise gen.Return(self.message)
+
+
+class InstallTests(testing.AsyncTestCase):
+
+    @testing.gen_test(timeout=10)
+    def should_override_settings_with_env_var_settings_test(self):
+        amqp_env_vars = {
+            'AMQP_URL': 'amqp://guest:guest@127.0.0.1:5672/%2f',
+            'AMQP_TIMEOUT': '15',
+            'AMQP_RECONNECT_DELAY': '7',
+            'AMQP_CONNECTION_ATTEMPTS': '2',
+        }
+        app = web.Application()
+        with mock.patch.dict('os.environ', amqp_env_vars):
+            amqp.install(app,
+                         url=AMQP_URL,
+                         timeout=8,
+                         reconnect_delay=5,
+                         connection_attempts=3)
+
+            self.assertEqual(app.amqp._url,
+                             amqp_env_vars['AMQP_URL'])
+            self.assertEqual(app.amqp._timeout,
+                             int(amqp_env_vars['AMQP_TIMEOUT']))
+            self.assertEqual(app.amqp._reconnect_delay,
+                             int(amqp_env_vars['AMQP_RECONNECT_DELAY']))
+            self.assertEqual(app.amqp._connection_attempts,
+                             int(amqp_env_vars['AMQP_CONNECTION_ATTEMPTS']))
+
+    @testing.gen_test(timeout=10)
+    def should_raise_attribute_error_when_timeout_lt_reconnect_delay_test(self):
+        with self.assertRaises(AttributeError) as context:
+            amqp.install(web.Application(),
+                         url=AMQP_URL,
+                         timeout=4,
+                         reconnect_delay=5)
+
+            self.assertTrue(
+                'Reconnection must be less than timeout' == str(
+                    context.exception))
+
+    @testing.gen_test(timeout=10)
+    def should_raise_attribute_error_when_timeout_eq_reconnect_delay_test(self):
+        with self.assertRaises(AttributeError) as context:
+            amqp.install(web.Application(),
+                         url=AMQP_URL,
+                         timeout=5,
+                         reconnect_delay=5)
+
+            self.assertTrue(
+                'Reconnection must be less than timeout' == str(
+                    context.exception))
+
+
+class EventsTests(BaseTestCase):
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_ready_test(self):
+        yield self.amqp_ready.wait()
+        self.assertTrue(self.ready_called)
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_unavailable_when_connection_closed_test(self):
+        yield self.amqp_ready.wait()
+        self.amqp_ready.clear()
+        self.clear_event_tracking()
+        LOGGER.info('Closing AMQP connection')
+        self.app.amqp._connection.close()
+        yield self.amqp_ready.wait()
+        self.assertTrue(self.unavailable_called)
+
+    @testing.gen_test(timeout=10)
+    def should_not_call_on_unavailable_when_closing_closed_connection_test(self):
+        yield self.amqp_ready.wait()
+        self.amqp_ready.clear()
+        self.clear_event_tracking()
+        LOGGER.info('Mocking Closing state')
+        self.app.amqp._state = self.app.amqp.STATE_CLOSING
+        LOGGER.info('Closing AMQP connection')
+        self.app.amqp._connection.close()
+        self.assertFalse(self.unavailable_called)
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_unavailable_when_connection_blocked_test(self):
+        yield self.amqp_ready.wait()
+        self.clear_event_tracking()
+        LOGGER.info('Calling _on_connection_blocked')
+        with mock.patch(PIKA_BLOCKED_PATH) as blocked:
+            blocked.reason = 'Testing'
+            self.app.amqp._on_connection_blocked(blocked)
+            self.assertTrue(self.unavailable_called)
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_ready_when_connection_unblocked_test(self):
+        yield self.amqp_ready.wait()
+        self.amqp_ready.clear()
+        self.clear_event_tracking()
+        LOGGER.info('Calling _on_connection_unblocked')
+        with mock.patch(PIKA_UNBLOCKED_PATH) as unblocked:
+            self.app.amqp._on_connection_unblocked(unblocked)
+        yield self.amqp_ready.wait()
+        self.assertTrue(self.ready_called)
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_unavailable_when_channel_closed_test(self):
+        yield self.amqp_ready.wait()
+        self.amqp_ready.clear()
+        self.clear_event_tracking()
+        LOGGER.info('Closing AMQP channel')
+        self.app.amqp.channel.close()
+        yield self.amqp_ready.wait()
+        self.assertTrue(self.unavailable_called)
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_unavailable_when_channel_open_test(self):
+        yield self.amqp_ready.wait()
+        self.amqp_ready.clear()
+        self.clear_event_tracking()
+        LOGGER.info('Calling _on_channel_open')
+        with mock.patch(PIKA_CHANNEL_PATH) as channel:
+            self.app.amqp._on_channel_open(channel)
+        yield self.amqp_ready.wait()
+        self.assertTrue(self.ready_called)
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_unavailable_when_channel_flow_inactive_test(self):
+        yield self.amqp_ready.wait()
+        self.amqp_ready.clear()
+        self.clear_event_tracking()
+        LOGGER.info('Calling _on_channel_flow (active=False)')
+        with mock.patch(PIKA_FLOW_PATH) as flow:
+            flow.active = False
+            self.app.amqp._on_channel_flow(flow)
+            self.assertTrue(self.unavailable_called)
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_ready_when_channel_flow_active_test(self):
+        yield self.amqp_ready.wait()
+        self.amqp_ready.clear()
+        self.clear_event_tracking()
+        LOGGER.info('Calling _on_channel_flow (active=True)')
+        with mock.patch(PIKA_FLOW_PATH) as flow:
+            flow.active = True
+            self.app.amqp._on_channel_flow(flow)
+        yield self.amqp_ready.wait()
+        self.assertTrue(self.ready_called)
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_message_returned_test(self):
+        yield self.amqp_ready.wait()
+        self.clear_event_tracking()
+        LOGGER.info('Calling _on_message_returned')
+        with mock.patch(PIKA_CHANNEL_PATH) as channel, \
+                mock.patch(PIKA_METHOD_PATH) as method, \
+                mock.patch(PIKA_PROPERTIES_PATH) as properties:
+            method.exchange = self.exchange
+            method.routing_key = self.routing_key
+            method.reply_text = 'TESTING'
+            properties.correlation_id = self.correlation_id
+            properties.message_id = str(uuid.uuid4())
+            self.app.amqp._on_message_returned(channel, method, properties, "")
+            self.assertTrue(self.message_returned_called)
+            self.assertEqual(self.exchange, self.returned_message['exchange'])
+            self.assertEqual(self.routing_key,
+                             self.returned_message['routing_key'])
+            self.assertEqual("", self.returned_message['body'])
+            self.assertEqual(properties, self.returned_message['properties'])
+            self.assertEqual('TESTING', self.message_returned_error)
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_persistent_failure_when_state_set_connecting_test(self):
+        yield self.test_queue_bound.wait()
+        yield self.amqp_ready.wait()
+        LOGGER.info('Mocking Connecting state')
+        self.app.amqp._state = self.app.amqp.STATE_CONNECTING
+        self._send_message_expecting_persistent_failure()
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_persistent_failure_when_state_set_closing_test(self):
+        yield self.test_queue_bound.wait()
+        yield self.amqp_ready.wait()
+        LOGGER.info('Mocking Closing state')
+        self.app.amqp._state = self.app.amqp.STATE_CLOSING
+        self._send_message_expecting_persistent_failure()
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_persistent_failure_when_state_set_closed_test(self):
+        yield self.test_queue_bound.wait()
+        yield self.amqp_ready.wait()
+        LOGGER.info('Mocking Closed state')
+        self.app.amqp._state = self.app.amqp.STATE_CLOSED
+        self._send_message_expecting_persistent_failure()
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_persistent_failure_when_connection_closed_test(self):
+        yield self.test_queue_bound.wait()
+        yield self.amqp_ready.wait()
+        LOGGER.info('Closing AMQP connection')
+        self.app.amqp.close()
+        self._send_message_expecting_persistent_failure()
+
+    @testing.gen_test(timeout=10)
+    def should_call_on_persistent_failure_when_connection_blocked_test(self):
+        yield self.test_queue_bound.wait()
+        yield self.amqp_ready.wait()
+        LOGGER.info('Calling _on_connection_blocked')
+        with mock.patch(PIKA_BLOCKED_PATH) as blocked:
+            blocked.reason = 'Testing'
+            self.app.amqp._on_connection_blocked(blocked)
+            self._send_message_expecting_persistent_failure()
+
+    def _send_message_expecting_persistent_failure(self):
+        self.clear_event_tracking()
+        message = bytes(bytearray(range(255, 0, -1)))
+        properties = {'content_type': 'application/octet-stream'}
+        yield self.app.amqp.publish(self.exchange, self.routing_key, message,
+                                    self.handler.app_id, self.correlation_id,
+                                    properties)
+        self.assertTrue(self.persistent_failure_called)
+        self.assertEqual(self.exchange, self.failed_message['exchange'])
+        self.assertEqual(self.routing_key, self.failed_message['routing_key'])
+        self.assertEqual(message, self.failed_message['body'])
+        self.assertEqual(properties, self.failed_message['properties'])
 
 
 class AMQPIntegrationTests(BaseTestCase):
 
     @testing.gen_test(timeout=10)
-    def publishing_tests(self):
-        yield self.ready.wait()
+    def should_publish_message_test(self):
+        yield self.test_queue_bound.wait()
+
         LOGGER.info('Should be ready')
+
+        properties = {'content_type': 'application/octet-stream'}
+
         message = bytes(bytearray(range(255, 0, -1)))
-        yield self.amqp.publish(self.exchange, self.routing_key, message,
-                                {'content_type': 'application/octet-stream'})
+        yield self.app.amqp.publish(
+            self.exchange,
+            self.routing_key,
+            message,
+            self.handler.app_id,
+            self.correlation_id,
+            properties
+        )
+
         LOGGER.info('Published')
+
         result = yield self.get_message()
-        self.assertEqual(message, result[2])
+        self.assertEqual(message, result['body'])
+        self.assertEqual(properties['content_type'],
+                         result['properties'].content_type)
+
+    @testing.gen_test(timeout=10)
+    def should_clobber_mandatory_properties_test(self):
+        yield self.test_queue_bound.wait()
+
+        LOGGER.info('Should be ready')
+
+        my_app_id = str(uuid.uuid4())
+        my_correlation_id = str(uuid.uuid4())
+        my_message_id = str(uuid.uuid4())
+
+        properties = {
+            'content_type': 'application/octet-stream',
+            'app_id': my_app_id,
+            'correlation_id': my_correlation_id,
+            'message_id': my_message_id,
+            'timestamp': 0,
+        }
+
+        message = bytes(bytearray(range(255, 0, -1)))
+        yield self.app.amqp.publish(
+            self.exchange,
+            self.routing_key,
+            message,
+            self.handler.app_id,
+            self.correlation_id,
+            properties
+        )
+
+        LOGGER.info('Published')
+
+        result = yield self.get_message()
+        self.assertNotEqual(my_app_id, result['properties'].app_id)
+        self.assertNotEqual(
+            my_correlation_id, result['properties'].correlation_id)
+        self.assertNotEqual(my_message_id, result['properties'].message_id)
+        self.assertNotEqual(0, result['properties'].timestamp)
+
+    @testing.gen_test(timeout=10)
+    def should_preserve_additional_properties_test(self):
+        yield self.test_queue_bound.wait()
+
+        LOGGER.info('Should be ready')
+
+        properties = {
+            'content_type': 'application/octet-stream',
+            'priority': 252,
+        }
+
+        message = bytes(bytearray(range(255, 0, -1)))
+        yield self.app.amqp.publish(
+            self.exchange,
+            self.routing_key,
+            message,
+            self.handler.app_id,
+            self.correlation_id,
+            properties
+        )
+
+        LOGGER.info('Published')
+
+        result = yield self.get_message()
+        self.assertEqual('application/octet-stream',
+                         result['properties'].content_type)
+        self.assertEqual(252, result['properties'].priority)
+
+    @testing.gen_test(timeout=10)
+    def should_set_default_app_id_test(self):
+        yield self.test_queue_bound.wait()
+
+        LOGGER.info('Should be ready')
+
+        default_app_id = '{}/{}'.format(multiprocessing.current_process().name,
+                                        os.getpid())
+
+        properties = {'content_type': 'application/octet-stream'}
+
+        message = bytes(bytearray(range(255, 0, -1)))
+        yield self.app.amqp.publish(
+            self.exchange,
+            self.routing_key,
+            message,
+            None,
+            self.correlation_id,
+            properties
+        )
+
+        LOGGER.info('Published')
+
+        result = yield self.get_message()
+        self.assertEqual(default_app_id, result['properties'].app_id)
+
+    @testing.gen_test(timeout=10)
+    def should_publish_message_via_handler_test(self):
+        yield self.test_queue_bound.wait()
+
+        LOGGER.info('Should be ready')
+
+        message = bytes(bytearray(range(255, 0, -1)))
+        properties = {'content_type': 'application/octet-stream'}
+
+        yield self.handler.amqp_publish(
+            self.exchange,
+            self.routing_key,
+            message,
+            properties
+        )
+
+        LOGGER.info('Published')
+
+        result = yield self.get_message()
+
+        self.assertEqual(message, result['body'])
+        self.assertEqual(self.handler.app_id, result['properties'].app_id)
+        self.assertEqual(self.handler.correlation_id,
+                         result['properties'].correlation_id)
+        self.assertEqual(properties['content_type'],
+                         result['properties'].content_type)


### PR DESCRIPTION
This takes the latest internal AMQP publisher and refactors the connection-handling portion of it into this sprocket.

The version has been bumped to 2.0.0 as there are contract changes in the sprocket.
