### PR TITLE
Reset ci environment back to trusty.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: trusty
 python:
 - 3.5
 - 3.6
-- 3.7
 services:
 - rabbitmq
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: python
-dist: xenial
+dist: trusty
 python:
 - 3.5
 - 3.6

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Python Compatibility
 --------------------
 - python 3.5
 - python 3.6
-- python 3.7
+- python 3.7 (currently untested in travis-ci).
 
 Requirements
 ------------


### PR DESCRIPTION
Reset the ci environment back to trusty because RabbitMQ is not currently
available in xenial environments, and is required to run tests.