### PR TITLE
Fix 2 issues with reopening a channel and publishing confirmation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 sudo: false
 language: python
-dist: trusty
+dist: xenial
 python:
 - 3.5
 - 3.6
 - 3.7
 services:
-- docker
+- rabbitmq
+addons:
+  apt:
+    packages:
+      - rabbitmq-server
 install:
 - pip install -r requires/testing.txt -r docs/requirements.txt codecov
-before_script:
-- ./bootstrap.sh
 script:
 - nosetests
 after_success:
@@ -23,6 +25,6 @@ deploy:
   password:
     secure: IJVu1MUk2NtRprWkYL+prPRbWrDdSiP+L06S6xERqYnu+fy1ez8/zODazkQGKagXAAujbJK8OwyCgoMzCGDNHV3/NfFtz9dirGVAD2rXZ6AVfHjtEh31L2b2YzXEK0EnBMRsYRjsqLva6q7tfxzjMWKFria25wsd9bN8VlofNDQ=
   on:
-    python: 3.6
+    python: 3.7
     tags: true
     repo: sprockets/sprockets.mixins.amqp

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ dist: trusty
 python:
 - 3.5
 - 3.6
+- 3.7
 services:
-- rabbitmq
+- docker
 install:
 - pip install -r requires/testing.txt -r docs/requirements.txt codecov
+before_script:
+- ./bootstrap.sh
 script:
 - nosetests
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Python Compatibility
 --------------------
 - python 3.5
 - python 3.6
-- python 3.7 (currently untested in travis-ci).
+- python 3.7
 
 Requirements
 ------------
@@ -106,11 +106,12 @@ Source
 Running Tests Locally
 ---------------------
 
-You'll need to have python 3.7 installed, and RabbitMQ installed locally running on port 5672 of localhost.
+You'll need to have python 3.7 installed.
 
 -- $ python3.7 -m venv env
 -- $ env/bin/activate
 -- (env) $ pip install -r requires/testing.txt
+-- (env) $ ./bootstrap.sh
 -- (env) $ nosetests
 
 License

--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ Source
 Running Tests Locally
 ---------------------
 
-You'll need to have python 3.7 installed.
+You'll need to have python 3.7, Docker and Docker Compose installed.
 
 -- $ python3.7 -m venv env
 -- $ env/bin/activate

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,7 +9,7 @@ get_exposed_port() {
 
 rm -rf build && mkdir build
 
-docker-compose down --timeout 0 --volumes --remove-orphans
+docker-compose down --volumes --remove-orphans
 docker-compose pull -q
 docker-compose up -d
 
@@ -17,7 +17,6 @@ echo "Environment variables (build/test-environment):"
 tee build/test-environment << EOF
 export AMQP_EXCHANGE=amq.topic
 export AMQP_URL=amqp://guest:guest@$TEST_HOST:$(get_exposed_port rabbitmq 5672)/%2f
-export ASYNC_TEST_TIMEOUT=10
 export RABBIMQ_URL=http://guest:guest@$TEST_HOST:$(get_exposed_port rabbitmq 15672)
 EOF
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -e
+
+TEST_HOST="${TEST_HOST:-127.0.0.1}"
+
+get_exposed_port() {
+    docker-compose port "$@" | cut -d: -f2
+}
+
+rm -rf build && mkdir build
+
+docker-compose down --timeout 0 --volumes --remove-orphans
+docker-compose pull -q
+docker-compose up -d
+
+echo "Environment variables (build/test-environment):"
+tee build/test-environment << EOF
+export AMQP_EXCHANGE=amq.topic
+export AMQP_URL=amqp://guest:guest@$TEST_HOST:$(get_exposed_port rabbitmq 5672)/%2f
+export ASYNC_TEST_TIMEOUT=10
+export RABBIMQ_URL=http://guest:guest@$TEST_HOST:$(get_exposed_port rabbitmq 15672)
+EOF
+
+echo 'Bootstrap complete'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "2.4"
+services:
+  rabbitmq:
+    image: rabbitmq:management-alpine
+    ports:
+      - 5672:5672
+      - 15672:15672

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 Version History
 ===============
 
+`2.2.0`_ Aug 8, 2019
+---------------------
+- Fix issue opening a channel is not checking if the conn is still open
+- Fix issue with publishing confirmation bookkeeping not reset when channel is reopened
+
 `2.1.5`_ July 3, 2019
 ---------------------
 - Remove official support for python versions less than 3.5

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,8 @@ Version History
 ---------------------
 - Fix issue opening a channel is not checking if the conn is still open
 - Fix issue with publishing confirmation bookkeeping not reset when channel is reopened
+- Add bootstrap and docker-compose instead of using local rabbitmq
+- Update CI to run bootstrap before tests
 
 `2.1.5`_ July 3, 2019
 ---------------------
@@ -82,7 +84,8 @@ Version History
 ----------------------
  - Initial implementation
 
-.. _Next Release: https://github.com/sprockets/sprockets.amqp/compare/2.1.5...HEAD
+.. _Next Release: https://github.com/sprockets/sprockets.amqp/compare/2.2.0...HEAD
+.. _2.2.0: https://github.com/sprockets/sprockets.amqp/compare/2.1.5...2.2.0
 .. _2.1.5: https://github.com/sprockets/sprockets.amqp/compare/2.1.4...2.1.5
 .. _2.1.4: https://github.com/sprockets/sprockets.amqp/compare/2.1.3...2.1.4
 .. _2.1.3: https://github.com/sprockets/sprockets.amqp/compare/2.1.2...2.1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [bdist_wheel]
 universal = 1
 
+[coverage:report]
+show_missing = 1
+
 [nosetests]
 cover-branches = 1
 cover-erase = 1

--- a/sprockets/mixins/amqp/__init__.py
+++ b/sprockets/mixins/amqp/__init__.py
@@ -31,7 +31,7 @@ except ImportError:  # pragma: nocover
     concurrent, ioloop, exceptions, pika = \
         object(), object(), object(), object()
 
-__version__ = '2.1.5'
+__version__ = '2.2.0'
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,13 @@
+import os
+
+
+def setup_module():
+    try:
+        with open('build/test-environment') as f:
+            for line in f:
+                if line.startswith('export '):
+                    line = line[7:]
+                name, _, value = line.strip().partition('=')
+                os.environ[name] = value
+    except IOError:
+        pass


### PR DESCRIPTION
This PR covers the following:

- Fix issue opening a channel is not checking if the conn is still open
- Fix issue with publishing confirmation bookkeeping not reset when channel is reopened
- Add bootstrap and docker-compose instead of using local rabbitmq
- Update CI to run bootstrap before tests