### PR TITLE
Only include sprockets.mixins.amqp package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests']),
     namespace_packages=['sprockets', 'sprockets.mixins'],
     install_requires=read_requirements('installation.txt'),
     zip_safe=True)


### PR DESCRIPTION
the tests were previously included in the package and were thus importable as `tests` when installed.